### PR TITLE
enter message property of error object directly

### DIFF
--- a/TopicWhiz/src/components/auth/forgot-password.js
+++ b/TopicWhiz/src/components/auth/forgot-password.js
@@ -20,7 +20,7 @@ module.exports = React.createClass({
       .then(() => {
         this.setState({result: 'Password reset sent successfully.'})
       }, (error) => {
-        this.setState({result: error})
+        this.setState({result: error.message})
       })
   },
 


### PR DESCRIPTION
the original implementation returend an error object which throws a react-native error. entering the message property of that object directly makes that work.
